### PR TITLE
Fix .travis.yml: value for smalltalk should be a list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: smalltalk
 sudo: false
-smalltalk: Pharo-5.0
+smalltalk:
+  - Pharo-5.0
 env:
   global:
     - BASELINE="WorkLog"


### PR DESCRIPTION
I got a build failure in my repository due to the value for `smalltalk` not being a list value. Turning it into a list fixed it.

See https://github.com/hpi-swa/smalltalkCI/issues/39 for discussion.
